### PR TITLE
Renaming 'owasp:api3:2019-rate-limit', 'owasp:api3:2019-rate-limit-retry-after' and 'owasp:api3:2019-rate-limit-responses-429'

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ You should see some output like this:
   44:17      warning  owasp:api3:2019-define-error-responses-400:400 response should be defined.. Missing responses[400]  paths./upload.post.responses
   44:17      warning  owasp:api3:2019-define-error-responses-429:429 response should be defined.. Missing responses[429]  paths./upload.post.responses
   44:17      warning  owasp:api3:2019-define-error-responses-500:500 response should be defined.. Missing responses[500]  paths./upload.post.responses
-  45:15        error  owasp:api3:2019-rate-limit                  All 2XX and 4XX responses should define rate limiting headers.  paths./upload.post.responses[201]
-  47:15        error  owasp:api3:2019-rate-limit                  All 2XX and 4XX responses should define rate limiting headers.  paths./upload.post.responses[401]
-  53:15        error  owasp:api3:2019-rate-limit                  All 2XX and 4XX responses should define rate limiting headers.  paths./upload.post.responses[403]
-  59:15        error  owasp:api3:2019-rate-limit                  All 2XX and 4XX responses should define rate limiting headers.  paths./upload.post.responses[409]
-  65:15        error  owasp:api3:2019-rate-limit                  All 2XX and 4XX responses should define rate limiting headers.  paths./upload.post.responses[422]
+  45:15        error  owasp:api4:2019-rate-limit                  All 2XX and 4XX responses should define rate limiting headers.  paths./upload.post.responses[201]
+  47:15        error  owasp:api4:2019-rate-limit                  All 2XX and 4XX responses should define rate limiting headers.  paths./upload.post.responses[401]
+  53:15        error  owasp:api4:2019-rate-limit                  All 2XX and 4XX responses should define rate limiting headers.  paths./upload.post.responses[403]
+  59:15        error  owasp:api4:2019-rate-limit                  All 2XX and 4XX responses should define rate limiting headers.  paths./upload.post.responses[409]
+  65:15        error  owasp:api4:2019-rate-limit                  All 2XX and 4XX responses should define rate limiting headers.  paths./upload.post.responses[422]
  193:16  information  owasp:api2:2019-protection-global-safe      This operation is not protected by any security scheme.  paths./sites.get.security
  210:16  information  owasp:api2:2019-protection-global-safe      This operation is not protected by any security scheme.  paths./species.get.security
 ```

--- a/__tests__/owasp-api4-2019-rate-limit-retry-after.test.ts
+++ b/__tests__/owasp-api4-2019-rate-limit-retry-after.test.ts
@@ -1,7 +1,7 @@
 import { DiagnosticSeverity } from "@stoplight/types";
 import testRule from "./__helpers__/helper";
 
-testRule("owasp:api3:2019-rate-limit-retry-after", [
+testRule("owasp:api4:2019-rate-limit-retry-after", [
 	{
 		name: "valid case",
 		document: {

--- a/__tests__/owasp-api4-2019-rate-limit.test.ts
+++ b/__tests__/owasp-api4-2019-rate-limit.test.ts
@@ -1,7 +1,7 @@
 import { DiagnosticSeverity } from "@stoplight/types";
 import testRule from "./__helpers__/helper";
 
-testRule("owasp:api3:2019-rate-limit", [
+testRule("owasp:api4:2019-rate-limit", [
 	{
 		name: "valid use of IETF Draft HTTP RateLimit Headers",
 		document: {

--- a/src/ruleset.ts
+++ b/src/ruleset.ts
@@ -357,7 +357,7 @@ export default {
     /**
      * @author: Phil Sturgeon <https://github.com/philsturgeon>
      */
-     "owasp:api3:2019-rate-limit": {
+     "owasp:api4:2019-rate-limit": {
       message: "All 2XX and 4XX responses should define rate limiting headers.",
       description: "Define proper rate limiting to avoid attackers overloading the API. There are many ways to implement rate-limiting, but most of them involve using HTTP headers, and there are two popular ways to do that:\n\nIETF Draft HTTP RateLimit Headers:. https://datatracker.ietf.org/doc/draft-ietf-httpapi-ratelimit-headers/\n\nCustomer headers like X-Rate-Limit-Limit (Twitter: https://developer.twitter.com/en/docs/twitter-api/rate-limits) or X-RateLimit-Limit (GitHub: https://docs.github.com/en/rest/overview/resources-in-the-rest-api)",
       formats: [oas3],
@@ -388,7 +388,7 @@ export default {
     /**
      * @author: Phil Sturgeon <https://github.com/philsturgeon>
      */
-     "owasp:api3:2019-rate-limit-retry-after": {
+     "owasp:api4:2019-rate-limit-retry-after": {
       message: "A 429 response should define a Retry-After header.",
       description:
         "Define proper rate limiting to avoid attackers overloading the API. Part of that involves setting a Retry-After header so well meaning consumers are not polling and potentially exacerbating problems.",
@@ -404,7 +404,7 @@ export default {
     /**
      * @author: Jason Harmon <https://github.com/jharmn>
      */
-    "owasp:api3:2019-rate-limit-responses-429": {
+    "owasp:api4:2019-rate-limit-responses-429": {
       description: "429 response should be defined.",
       message: "{{description}}. Missing {{property}}",
       severity: DiagnosticSeverity.Warning,


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the title above. -->

Renaming 'owasp:api3:2019-rate-limit', 'owasp:api3:2019-rate-limit-retry-after' and 'owasp:api3:2019-rate-limit-responses-429' to begin with 'owasp:api4...' to match the API4:2019 OWASP code.

## Motivation and Context
Looks like there was a typo in the naming of 3 of the rules. Perhaps should have been owasp:api4.. instead of owasp:api3... ?

#InsertIssueNumberHere

## Description
Renamed rule and tests


## How Has This Been Tested?
Ran unit tests


## Screenshot(s)/recordings(s)
<!-- If applicable, add screenshots or gifs to help demonstrate the changes. -->
<!-- If not applicable, remove this screenshots section before creating the PR. -->


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [ ] I have added error reporting and followed [the error reporting guidelines](???).
- [ ] I have added event tracking and followed [the event tracking guidelines](???).
- [ x] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [ ] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [ x] All new and existing tests pass locally (excluding flaky CI tests).
<!-- It's up to the discretion of the code reviewer(s) whether or not all of these must be checked before approval. -->
