### PR TITLE
what to do about additionalProperties

### DIFF
--- a/src/ruleset.ts
+++ b/src/ruleset.ts
@@ -653,17 +653,16 @@ export default {
      */
     "owasp:api6:2019-no-additionalProperties": {
       message:
-        "additionalProperties is disabled by default in OAS3.0, and should not be enabled.",
+        "additionalProperties is enabled by default in OAS3.0, and should be disabled.",
       description:
-        "OpenAPI v3.0 allows additional properties but is disabled by default. This feature should not be enabled as it can potentially lead to mass assignment issues, where unspecified fields are passed to the API without validation. Disable them with `additionalProperties: false` or add `maxProperties`.",
+        "Additional properties are enabled by default in modern OpenAPI and JSON Schema as it helps keep your API forwards compatible, but it can potentially lead to mass assignment issues, where unspecified fields are passed to the API without validation. Disable additional properties explicitly with `additionalProperties: false`.",
       severity: DiagnosticSeverity.Warning,
-      formats: [oas3_0],
-      given:
-        '$..[?(@ && @.type=="object" && @.additionalProperties && @.additionalProperties.type != "object" )]',
+      formats: [oas3],
+      given: '$..[?(@ && @.type=="object")]',
       then: [
         {
           field: "additionalProperties",
-          function: falsy,
+          function: defined,
         },
       ],
     },
@@ -675,10 +674,10 @@ export default {
     "owasp:api6:2019-constrained-additionalProperties": {
       message: "Objects should not allow unconstrained additionalProperties.",
       description:
-        "By default OpenAPI v3.1 enables additionalProperties. This feature should be turned off as it can potentially lead to mass assignment issues, where unspecified fields are passed to the API without validation. Alternatively it could be constrained with `maxProperties`",
+        "Additional properties are enabled by default in modern OpenAPI and JSON Schema as it helps keep your API forwards compatible, but it can potentially lead to mass assignment issues, where unspecified fields are passed to the API without validation. Disable additional properties explicitly with `additionalProperties: false`, or constrain the additional properties by providing a schema for their validation: `additionalProperties: { type: ... } }`.",
       severity: DiagnosticSeverity.Warning,
-      formats: [oas3_1],
-      given: '$..[?(@ && @.type=="object")]',
+      formats: [oas3],
+      given: '$..[?(@ && @.type=="object" && @.additionalProperties )]',
       then: [
         {
           function: schema,
@@ -690,12 +689,11 @@ export default {
                   const: false,
                 },
               },
-              // or it is constrained with maxProperties
+              // or it is constrained with a sub-schema
               {
                 additionalProperties: {
                   type: "object",
                 },
-                required: ["maxProperties"],
               },
             ],
           },

--- a/src/ruleset.ts
+++ b/src/ruleset.ts
@@ -653,12 +653,13 @@ export default {
      */
     "owasp:api6:2019-no-additionalProperties": {
       message:
-        "If the additionalProperties keyword is used it must be set to false.",
+        "additionalProperties is disabled by default in OAS3.0, and should not be enabled.",
       description:
-        "By default JSON Schema allows additional properties, which can potentially lead to mass assignment issues, where unspecified fields are passed to the API without validation. Disable them with `additionalProperties: false` or add `maxProperties`.",
+        "OpenAPI v3.0 allows additional properties but is disabled by default. This feature should not be enabled as it can potentially lead to mass assignment issues, where unspecified fields are passed to the API without validation. Disable them with `additionalProperties: false` or add `maxProperties`.",
       severity: DiagnosticSeverity.Warning,
-      formats: [oas3],
-      given: '$..[?(@ && @.type=="object" && @.additionalProperties)]',
+      formats: [oas3_0],
+      given:
+        '$..[?(@ && @.type=="object" && @.additionalProperties && @.additionalProperties.type != "object" )]',
       then: [
         {
           field: "additionalProperties",
@@ -674,15 +675,30 @@ export default {
     "owasp:api6:2019-constrained-additionalProperties": {
       message: "Objects should not allow unconstrained additionalProperties.",
       description:
-        "By default JSON Schema allows additional properties, which can potentially lead to mass assignment issues, where unspecified fields are passed to the API without validation. Disable them with `additionalProperties: false` or add `maxProperties`",
+        "By default OpenAPI v3.1 enables additionalProperties. This feature should be turned off as it can potentially lead to mass assignment issues, where unspecified fields are passed to the API without validation. Alternatively it could be constrained with `maxProperties`",
       severity: DiagnosticSeverity.Warning,
-      formats: [oas3],
-      given:
-        '$..[?(@ && @.type=="object" && @.additionalProperties &&  @.additionalProperties!=true &&  @.additionalProperties!=false )]',
+      formats: [oas3_1],
+      given: '$..[?(@ && @.type=="object")]',
       then: [
         {
-          field: "maxProperties",
-          function: defined,
+          function: schema,
+          schema: {
+            oneOf: [
+              // either additionalProperties is disabled
+              {
+                additionalProperties: {
+                  const: false,
+                },
+              },
+              // or it is constrained with maxProperties
+              {
+                additionalProperties: {
+                  type: "object",
+                },
+                required: ["maxProperties"],
+              },
+            ],
+          },
         },
       ],
     },


### PR DESCRIPTION
the functionality in the repo was contradicting itself, saying it had to be false but also another rule allowed it to be an object. OAS3.0 is additionalPorperties: false by default, and OAS3.1 is additionalProperties: true by default. It seems like we should address that, by making OAS3.1 users use additionalProperties, and saying it either needs to be false or an object with maxProperties set?

<!-- Provide a general summary of your changes in the title above. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
#InsertIssueNumberHere

## Description
<!-- Describe your technical changes in detail. -->


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Did you test the changes locally, in a PR environment, or somewhere else? -->
<!-- Were unit/integration/e2e/other tests added? If not, why? -->
<!-- Also describe how one or more persons giving a code review can verify your changes. -->


## Screenshot(s)/recordings(s)
<!-- If applicable, add screenshots or gifs to help demonstrate the changes. -->
<!-- If not applicable, remove this screenshots section before creating the PR. -->


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [ ] I have added error reporting and followed [the error reporting guidelines](???).
- [ ] I have added event tracking and followed [the event tracking guidelines](???).
- [ ] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [ ] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [ ] All new and existing tests pass locally (excluding flaky CI tests).
<!-- It's up to the discretion of the code reviewer(s) whether or not all of these must be checked before approval. -->
