### PR TITLE
enum or const string do not trigger owasp:api4:2019-string-restricted

### DIFF
--- a/__tests__/owasp-api4-2019-string-restricted.test.ts
+++ b/__tests__/owasp-api4-2019-string-restricted.test.ts
@@ -101,6 +101,40 @@ testRule("owasp:api4:2019-string-restricted", [
   },
 
   {
+    name: "valid case: enum (oas3)",
+    document: {
+      openapi: "3.0.0",
+      info: { version: "1.0" },
+      components: {
+        schemas: {
+          Foo: {
+            type: "string",
+            enum: [ "a", "b", "c" ]
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+
+  {
+    name: "valid case: const (oas3.1)",
+    document: {
+      openapi: "3.1.0",
+      info: { version: "1.0" },
+      components: {
+        schemas: {
+          Foo: {
+            type: "string",
+            const: "CONSTANT"
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+
+  {
     name: "invalid case: neither format or pattern (oas2)",
     document: {
       swagger: "2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "@types/jest": "^28.1.8",
         "jest": "^28.1.3",
         "ts-jest": "^28.0",
-        "tsup": "^6.5.0"
+        "tsup": "^6.5.0",
+        "typescript": "^4.9.5"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -5379,11 +5380,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
-      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9482,11 +9482,10 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
-      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
-      "dev": true,
-      "peer": true
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "@types/jest": "^28.1.8",
     "jest": "^28.1.3",
     "ts-jest": "^28.0",
-    "tsup": "^6.5.0"
+    "tsup": "^6.5.0",
+    "typescript": "^4.9.5"
   },
   "tsup": {
     "entry": [

--- a/src/ruleset.ts
+++ b/src/ruleset.ts
@@ -548,6 +548,12 @@ export default {
               {
                 required: ["pattern"],
               },
+              {
+                required: ["enum"],
+              },
+              {
+                required: ["const"],
+              },
             ],
           },
         },


### PR DESCRIPTION



<!-- Provide a general summary of your changes in the title above. -->

## Motivation and Context

Fixes #28

## Description

Updated `"owasp:api4:2019-string-restricted"` in `ruleset.ts` (near line 551) to add "enum" and "const" to the `oneOf` validation.

## How Has This Been Tested?

Added acceptance tests in `__tests__/owasp-api4-2019-string-restricted.test.ts`


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [ ] I have added error reporting and followed [the error reporting guidelines](???).
- [ ] I have added event tracking and followed [the event tracking guidelines](???).
- [ ] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [ ] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [ ] All new and existing tests pass locally (excluding flaky CI tests).
<!-- It's up to the discretion of the code reviewer(s) whether or not all of these must be checked before approval. -->
