### PR TITLE
fix: module.exports present in ESM bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ echo 'extends: ["@stoplight/spectral-owasp-ruleset"]' > .spectral.yaml
 _If you're using VS Code or Stoplight Studio then the NPM modules will not be available. Instead you can use the CDN hosted version:_
 
 ```
-echo 'extends: ["https://unpkg.com/@stoplight/spectral-owasp-ruleset@1.1.1/dist/ruleset.js"]' > .spectral.yaml
+echo 'extends: ["https://unpkg.com/@stoplight/spectral-owasp-ruleset/dist/ruleset.mjs"]' > .spectral.yaml
 ```
 
 _**Note:** You need to use the full URL with CDN hosted rulesets because Spectral [cannot follow redirects through extends](https://github.com/stoplightio/spectral/issues/2266)._

--- a/package.json
+++ b/package.json
@@ -48,26 +48,5 @@
     "ts-jest": "^28.0",
     "tsup": "^6.5.0",
     "typescript": "^4.9.5"
-  },
-  "tsup": {
-    "entry": [
-      "src/ruleset.ts"
-    ],
-    "clean": true,
-    "dts": true,
-    "format": [
-      "cjs",
-      "esm"
-    ],
-    "sourcemap": true,
-    "noExternal": [
-      "@stoplight/types"
-    ],
-    "external": [
-      "@stoplight/spectral-core"
-    ],
-    "footer": {
-      "js": "module.exports = module.exports.default;"
-    }
   }
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,20 @@
+import type { Options } from 'tsup';
+export default <Options>{
+  entry: ["src/ruleset.ts"],
+  clean: true,
+  dts: true,
+  target: "es2018",
+  format: ["cjs", "esm"],
+  sourcemap: true,
+  noExternal: ["@stoplight/types"],
+  external: ["@stoplight/spectral-core"],
+  footer({ format }) {
+    if (format === "cjs") {
+      return {
+        js: "module.exports = module.exports.default;",
+      };
+    }
+
+    return {};
+  },
+};


### PR DESCRIPTION
Should resolve https://github.com/stoplightio/spectral-owasp-ruleset/issues/33