### PR TITLE
Change `oneOf` to `anyOf` schema in owasp:api4:2019-string-restricted and owasp:api4:2019-string-limit

### DIFF
--- a/__tests__/owasp-api4-2019-string-limit.test.ts
+++ b/__tests__/owasp-api4-2019-string-limit.test.ts
@@ -51,7 +51,6 @@ testRule("owasp:api4:2019-string-limit", [
     errors: [],
   },
 
-
   {
     name: "valid case: oas3.0",
     document: {
@@ -61,7 +60,7 @@ testRule("owasp:api4:2019-string-limit", [
         schemas: {
           Foo: {
             type: "string",
-            enum: [ "a", "b", "c" ]
+            enum: ["a", "b", "c"],
           },
         },
       },
@@ -78,7 +77,43 @@ testRule("owasp:api4:2019-string-limit", [
         schemas: {
           Foo: {
             type: "string",
-            const: "constant"
+            const: "constant",
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+
+  {
+    name: "valid case: oas3.1",
+    document: {
+      openapi: "3.1.0",
+      info: { version: "1.0" },
+      components: {
+        schemas: {
+          Foo: {
+            type: "string",
+            const: "constant",
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+
+  {
+    name: "valid case: pattern and maxLength, oas3.1",
+    document: {
+      openapi: "3.1.0",
+      info: { version: "1.0" },
+      components: {
+        schemas: {
+          Foo: {
+            type: "string",
+            format: "hex",
+            pattern: "^[0-9a-fA-F]+$",
+            maxLength: 16
           },
         },
       },
@@ -99,7 +134,8 @@ testRule("owasp:api4:2019-string-limit", [
     },
     errors: [
       {
-        message: "Schema of type string must specify maxLength, enum, or const.",
+        message:
+          "Schema of type string must specify maxLength, enum, or const.",
         path: ["definitions", "Foo"],
         severity: DiagnosticSeverity.Error,
       },
@@ -121,7 +157,8 @@ testRule("owasp:api4:2019-string-limit", [
     },
     errors: [
       {
-        message: "Schema of type string must specify maxLength, enum, or const.",
+        message:
+          "Schema of type string must specify maxLength, enum, or const.",
         path: ["components", "schemas", "Foo"],
         severity: DiagnosticSeverity.Error,
       },
@@ -142,7 +179,8 @@ testRule("owasp:api4:2019-string-limit", [
     },
     errors: [
       {
-        message: "Schema of type string must specify maxLength, enum, or const.",
+        message:
+          "Schema of type string must specify maxLength, enum, or const.",
         path: ["components", "schemas", "Foo"],
         severity: DiagnosticSeverity.Error,
       },

--- a/__tests__/owasp-api4-2019-string-restricted.test.ts
+++ b/__tests__/owasp-api4-2019-string-restricted.test.ts
@@ -50,7 +50,7 @@ testRule("owasp:api4:2019-string-restricted", [
   },
 
   {
-    name: "valid case: format (oas3)",
+    name: "valid case: pattern (oas3)",
     document: {
       openapi: "3.0.0",
       info: { version: "1.0" },
@@ -110,6 +110,25 @@ testRule("owasp:api4:2019-string-restricted", [
           Foo: {
             type: "string",
             enum: ["a", "b", "c"],
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+
+  {
+    name: "valid case: format + pattern (oas3.1)",
+    document: {
+      openapi: "3.1.0",
+      info: { version: "1.0" },
+      components: {
+        schemas: {
+          foo: {
+            type: "string",
+            format: "hex",
+            pattern: "^[0-9a-fA-F]+$",
+            maxLength: 16
           },
         },
       },

--- a/src/ruleset.ts
+++ b/src/ruleset.ts
@@ -551,7 +551,7 @@ export default {
     "owasp:api4:2019-string-restricted": {
       message: "Schema of type string must specify a format, pattern, enum, or const.",
       description:
-        "To avoid unexpected values being sent or leaked, ensure that strings have either a format or a RegEx pattern. This can be done using `format`, `pattern`, `enum` or `const`.",
+        "To avoid unexpected values being sent or leaked, ensure that strings have either a `format`, RegEx `pattern`, `enum`, or `const`.",
       severity: DiagnosticSeverity.Error,
       given: "#StringProperties",
       then: {
@@ -559,7 +559,7 @@ export default {
         functionOptions: {
           schema: {
             type: "object",
-            oneOf: [
+            anyOf: [
               {
                 required: ["format"],
               },

--- a/src/ruleset.ts
+++ b/src/ruleset.ts
@@ -529,7 +529,7 @@ export default {
         functionOptions: {
           schema: {
             type: "object",
-            oneOf: [
+            anyOf: [
               {
                 required: ["maxLength"],
               },


### PR DESCRIPTION
The use of `oneOf` means that _only_ one of the schema constraints may be true, but it is valid if two or more of the string schema constraint keywords are present: `format`, `pattern`, `enum`, `const`.

<!-- Provide a general summary of your changes in the title above. -->

## Motivation and Context

Fixes #42

## Description

In the "owasp:api4:2019-string-restricted" rule, change `oneOf` (exclusive or) to `anyOf` (inclusive or)

## How Has This Been Tested?

Added a new test case for a `type: string` schema that has _both_ `format` and `pattern`.


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [ ] I have added error reporting and followed [the error reporting guidelines](???).
- [ ] I have added event tracking and followed [the event tracking guidelines](???).
- [ ] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [X] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [X] All new and existing tests pass locally (excluding flaky CI tests).
<!-- It's up to the discretion of the code reviewer(s) whether or not all of these must be checked before approval. -->
