### PR TITLE
Removes duplicated test case for Integer Limit Rule

### DIFF
--- a/__tests__/owasp-api4-2019-integer-limit.test.ts
+++ b/__tests__/owasp-api4-2019-integer-limit.test.ts
@@ -121,29 +121,6 @@ testRule("owasp:api4:2019-integer-limit", [
   },
 
   {
-    name: "invalid case: only maximum",
-    document: {
-      openapi: "3.1.0",
-      info: { version: "1.0" },
-      components: {
-        schemas: {
-          Foo: {
-            type: "integer",
-            maximum: 99,
-          },
-        },
-      },
-    },
-    errors: [
-      {
-        message: "Schema of type integer must specify minimum and maximum.",
-        path: ["components", "schemas", "Foo"],
-        severity: DiagnosticSeverity.Error,
-      },
-    ],
-  },
-
-  {
     name: "invalid case: only exclusiveMinimum",
     document: {
       openapi: "3.1.0",


### PR DESCRIPTION
## Motivation and Context
Duplicated tests should not exist. 

## Description
Removes duplicated test case for the integer limit rule. Duplicated tests may be confusing.
