### PR TITLE
Fixes #49 by adding rules for JSON Schema unevaluatedProperties keyword

### DIFF
--- a/__tests__/owasp-api6-2019-no-unevaluatedProperties.test.ts
+++ b/__tests__/owasp-api6-2019-no-unevaluatedProperties.test.ts
@@ -1,0 +1,79 @@
+import { DiagnosticSeverity } from "@stoplight/types";
+import testRule from "./__helpers__/helper";
+
+testRule("owasp:api6:2019-no-unevaluatedProperties", [
+
+  {
+    name: "valid case: oas3_1",
+    document: {
+      openapi: "3.1.0",
+      info: { version: "1.0" },
+      components: {
+        schemas: {
+          Foo: {
+            type: "object",
+            unevaluatedProperties: false,
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+
+  {
+    name: "valid case: no unevaluatedProperties defined (oas3_1)",
+    document: {
+      openapi: "3.1.0",
+      info: { version: "1.0" },
+      components: {
+        schemas: {
+          Foo: {
+            type: "object",
+          },
+        },
+      },
+    },
+    errors: [],
+  },
+
+  {
+    name: "valid case: unevaluatedProperties set to false (oas3_1)",
+    document: {
+      openapi: "3.1.0",
+      info: { version: "1.0" },
+      components: {
+        schemas: {
+          Foo: {
+            type: "object",
+            unevaluatedProperties: false,
+          },
+        },
+      },
+    },
+    errors: [{}],
+  },
+
+  {
+    name: "invalid case: unevaluatedProperties set to true (oas3_1)",
+    document: {
+      openapi: "3.1.0",
+      info: { version: "1.0" },
+      components: {
+        schemas: {
+          Foo: {
+            type: "object",
+            unevaluatedProperties: true,
+          },
+        },
+      },
+    },
+    errors: [
+      {
+        message:
+          "If the unevaluatedProperties keyword is used it must be set to false.",
+        path: ["components", "schemas", "Foo", "unevaluatedProperties"],
+        severity: DiagnosticSeverity.Warning,
+      },
+    ],
+  },
+]);

--- a/src/ruleset.ts
+++ b/src/ruleset.ts
@@ -702,7 +702,7 @@ export default {
       description:
         "By default JSON Schema allows unevaluated properties, which can potentially lead to mass assignment issues, where unspecified fields are passed to the API without validation. Disable them with `unevaluatedProperties: false` or add `maxProperties`.",
       severity: DiagnosticSeverity.Warning,
-      formats: [oas3],
+      formats: [oas3_1],
       given: '$..[?(@ && @.type=="object" && @.unevaluatedProperties)]',
       then: [
         {
@@ -742,7 +742,7 @@ export default {
       description:
         "By default JSON Schema allows unevaluated properties, which can potentially lead to mass assignment issues, where unspecified fields are passed to the API without validation. Disable them with `unevaluatedProperties: false` or add `maxProperties`",
       severity: DiagnosticSeverity.Warning,
-      formats: [oas3],
+      formats: [oas3_1],
       given:
         '$..[?(@ && @.type=="object" && @.unevaluatedProperties &&  @.unevaluatedProperties!=true &&  @.unevaluatedProperties!=false )]',
       then: [

--- a/src/ruleset.ts
+++ b/src/ruleset.ts
@@ -692,7 +692,7 @@ export default {
     },
 
     /**
-     * @author: David Biesack <https://github.com/davidbiesack>,
+     * @author: David Biesack <https://github.com/DavidBiesack>,
      * derived from owasp:api6:2019-no-additionalProperties
      * @see: https://github.com/italia/api-oas-checker/blob/master/security/objects.yml
      */
@@ -733,7 +733,7 @@ export default {
     },
 
     /**
-     * @author: David Biesack <https://github.com/davidbiesack>,
+     * @author: David Biesack <https://github.com/DavidBiesack>,
      * derived from owasp:api6:2019-constrained-additionalProperties
      * @see: https://github.com/italia/api-oas-checker/blob/master/security/objects.yml
      */

--- a/src/ruleset.ts
+++ b/src/ruleset.ts
@@ -692,6 +692,27 @@ export default {
     },
 
     /**
+     * @author: David Biesack <https://github.com/davidbiesack>,
+     * derived from owasp:api6:2019-no-additionalProperties
+     * @see: https://github.com/italia/api-oas-checker/blob/master/security/objects.yml
+     */
+    "owasp:api6:2019-no-unevaluatedProperties": {
+      message:
+        "If the unevaluatedProperties keyword is used it must be set to false.",
+      description:
+        "By default JSON Schema allows unevaluated properties, which can potentially lead to mass assignment issues, where unspecified fields are passed to the API without validation. Disable them with `unevaluatedProperties: false` or add `maxProperties`.",
+      severity: DiagnosticSeverity.Warning,
+      formats: [oas3],
+      given: '$..[?(@ && @.type=="object" && @.unevaluatedProperties)]',
+      then: [
+        {
+          field: "unevaluatedProperties",
+          function: falsy,
+        },
+      ],
+    },
+
+    /**
      * @author: Roberto Polli <https://github.com/ioggstream>
      * @see: https://github.com/italia/api-oas-checker/blob/master/security/objects.yml
      */
@@ -703,6 +724,27 @@ export default {
       formats: [oas3],
       given:
         '$..[?(@ && @.type=="object" && @.additionalProperties &&  @.additionalProperties!=true &&  @.additionalProperties!=false )]',
+      then: [
+        {
+          field: "maxProperties",
+          function: defined,
+        },
+      ],
+    },
+
+    /**
+     * @author: David Biesack <https://github.com/davidbiesack>,
+     * derived from owasp:api6:2019-constrained-additionalProperties
+     * @see: https://github.com/italia/api-oas-checker/blob/master/security/objects.yml
+     */
+    "owasp:api6:2019-constrained-unevaluatedProperties": {
+      message: "Objects should not allow unconstrained unevaluatedProperties.",
+      description:
+        "By default JSON Schema allows unevaluated properties, which can potentially lead to mass assignment issues, where unspecified fields are passed to the API without validation. Disable them with `unevaluatedProperties: false` or add `maxProperties`",
+      severity: DiagnosticSeverity.Warning,
+      formats: [oas3],
+      given:
+        '$..[?(@ && @.type=="object" && @.unevaluatedProperties &&  @.unevaluatedProperties!=true &&  @.unevaluatedProperties!=false )]',
       then: [
         {
           field: "maxProperties",


### PR DESCRIPTION
add rules for JSON Schema unevaluatedProperties keyword, similar to `additionalProperties`

## Motivation and Context

Fixes #49

## Description

Clone the rules


## How Has This Been Tested?

Added a jest testcase 

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [ ] I have added error reporting and followed [the error reporting guidelines](???).
- [ ] I have added event tracking and followed [the event tracking guidelines](???).
- [ ] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [x] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [x] All new and existing tests pass locally (excluding flaky CI tests).
<!-- It's up to the discretion of the code reviewer(s) whether or not all of these must be checked before approval. -->
