### PR TITLE
no refreshurl for client credentials flow in auth2

### DIFF
--- a/src/ruleset.ts
+++ b/src/ruleset.ts
@@ -269,7 +269,7 @@ export default {
       description:
         "Using short-lived access tokens is a good practice, and when using OAuth 2 this is done by using refresh tokens. If a malicious actor is able to get hold of an access token then rotation means that token might not work by the time they try to use it, or it could at least reduce how long they are able to perform malicious requests.",
       severity: DiagnosticSeverity.Error,
-      given: ['$.components.securitySchemes[?(@ && @.type=="oauth2")].flows.*'],
+      given: '$.components.securitySchemes[?(@ && @.type=="oauth2")].flows[?(@property != "clientCredentials")]',
       then: [
         {
           field: "refreshUrl",


### PR DESCRIPTION
client credentials flow, there are no refresh url. and https://www.rfc-editor.org/rfc/rfc6749#section-4.4.3 states that "a refresh token SHOULD NOT be included" in client credentials flow of auth2 and so there would be no point of a refresh url truth check. This change will check for refresh url in all auth2 flow except client credentials flow

<!-- Provide a general summary of your changes in the title above. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
#InsertIssueNumberHere

## Description
<!-- Describe your technical changes in detail. -->


## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Did you test the changes locally, in a PR environment, or somewhere else? -->
<!-- Were unit/integration/e2e/other tests added? If not, why? -->
<!-- Also describe how one or more persons giving a code review can verify your changes. -->


## Screenshot(s)/recordings(s)
<!-- If applicable, add screenshots or gifs to help demonstrate the changes. -->
<!-- If not applicable, remove this screenshots section before creating the PR. -->


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [x] I have added error reporting and followed [the error reporting guidelines](???).
- [x] I have added event tracking and followed [the event tracking guidelines](???).
- [x] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [x] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [x] All new and existing tests pass locally (excluding flaky CI tests).
<!-- It's up to the discretion of the code reviewer(s) whether or not all of these must be checked before approval. -->
