### PR TITLE
fixing Access-Control-Allow-Origin rule for response headers

### DIFF
--- a/src/ruleset.ts
+++ b/src/ruleset.ts
@@ -753,7 +753,7 @@ export default {
       message: "Header `{{property}}` should be defined on all responses.",
       description:
         'Setting up CORS headers will control which websites can make browser-based HTTP requests to your API, using either the wildcard "*" to allow any origin, or "null" to disable any origin. Alternatively you can use "Access-Control-Allow-Origin: https://example.com" to indicate that only requests originating from the specified domain (https://example.com) are allowed to access its resources.\n\nMore about CORS here: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS.',
-      given: "$..headers",
+      given: "$..[responses][*].headers",
       then: {
         field: "Access-Control-Allow-Origin",
         function: truthy,


### PR DESCRIPTION
Check for Access-Control-Allow-Origin doesn't need to check all the headers, it only need to check the response headers. Otherwise it will show the error for header schema defined in components.

<!-- Provide a general summary of your changes in the title above. -->

## Motivation and Context
The rule is creating false error, it says headers in components are missing Access-Control-Allow-Origin. This check should check only response headers, not header schema defined under components. header ref schema defined in components may have different name (for ex: '#/components/headers/AccessControlAllowOrigin'
        RateLimit-Limit:)
<!-- If it fixes an open issue, please link to the issue here. -->
#InsertIssueNumberHere

## Description
Updated the rule given to only check response headers
`given: $..[responses][*].headers`


## How Has This Been Tested?
This is tested locally in locally test environments and test and production grade API contracts (Open API specification) 

## Screenshot(s)/recordings(s)
<!-- If applicable, add screenshots or gifs to help demonstrate the changes. -->
<!-- If not applicable, remove this screenshots section before creating the PR. -->


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [ ] I have added error reporting and followed [the error reporting guidelines](???).
- [ ] I have added event tracking and followed [the event tracking guidelines](???).
- [ ] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [ ] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [x] All new and existing tests pass locally (excluding flaky CI tests).
<!-- It's up to the discretion of the code reviewer(s) whether or not all of these must be checked before approval. -->
