### PR TITLE
FIX add missing description to owasp:api5:2023-admin-security-unique

### DIFF
--- a/src/ruleset.ts
+++ b/src/ruleset.ts
@@ -661,7 +661,7 @@ export default {
 
     "owasp:api5:2023-admin-security-unique": {
       message: "{{error}}",
-      description: "",
+      description: "Ensure that administrative endpoints do not use the same security scheme as non-admin endpoints.",
       severity: DiagnosticSeverity.Error,
       given: "$",
       then: [


### PR DESCRIPTION
The rule owasp:api5:2023-admin-security-unique is missing a description. This causes the SARIF formatter in Spectral to produce invalid SARIF files. 

This fix adds a description to the rule.

<!-- Provide a general summary of your changes in the title above. -->

## Motivation and Context

The rule owasp:api5:2023-admin-security-unique is missing a description. This causes the SARIF formatter in Spectral to produce invalid SARIF files. 

Fixes the following issue in the Spectral github repo: https://github.com/stoplightio/spectral/issues/2610

## Description

This fix adds a basic description to the rule.


## How Has This Been Tested?

The updated ruleset has been used locally in Spectral against an OpenAPI spec. The SARIF formatter was used, and valid SARIF output was produced.

## Screenshot(s)/recordings(s)

N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [ ] I have added error reporting and followed [the error reporting guidelines](???).
- [ ] I have added event tracking and followed [the event tracking guidelines](???).
- [ ] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [ ] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [ ] All new and existing tests pass locally (excluding flaky CI tests).
<!-- It's up to the discretion of the code reviewer(s) whether or not all of these must be checked before approval. -->
